### PR TITLE
Case insensitive search, update levequest list while searching.

### DIFF
--- a/GUI/MainView.xaml
+++ b/GUI/MainView.xaml
@@ -72,7 +72,7 @@
                         <Image Source="http://xivdb.com/img/classes/set1/culinarian.png" Width="15" />
                     </ToggleButton>
                     <Label Content="Search:" />
-                    <TextBox Width="122" Text="{Binding Search}" />
+                    <TextBox Width="122" Text="{Binding Search, UpdateSourceTrigger=PropertyChanged}" />
                 </StackPanel>
 
                 <DataGrid AutoGenerateColumns="False" Grid.Row="1" ItemsSource="{Binding FilteredLeves}" IsReadOnly="True"

--- a/Models/WindowModelProvider.cs
+++ b/Models/WindowModelProvider.cs
@@ -182,7 +182,12 @@ namespace LeveGen.Models
         }
 
         public ICollectionView FilteredLeves { get; set; }
-     
+
+
+        private bool FilterMatches(string term)
+        {
+            return (term.IndexOf(Search, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
 
         private bool Filter(Leve i)
         {
@@ -190,7 +195,7 @@ namespace LeveGen.Models
                 return true;
             if(Search == null)
                 return validateToggle(i);
-            return (i.Name.Contains(Search) || i.ItemName.Contains(Search)) && validateToggle(i);
+            return (FilterMatches(i.Name) || FilterMatches(i.ItemName)) && validateToggle(i);
 
         }
         private ObservableCollection<Leve> _CurrentOrder = new ObservableCollection<Leve>();


### PR DESCRIPTION
Search is now being performed case insensitive for a better user-experience.
Wired the UpdateSourceTrigger so the filter would get applied as you type instead of the somewhat odd tab-out behaviour.