### PR TITLE
Explicitly set the timeout for ExPickupGuildLeve.

### DIFF
--- a/LeveGenerator.cs
+++ b/LeveGenerator.cs
@@ -46,15 +46,15 @@ namespace LeveGen
             var turninloc = $"{formatFloat(turnin.Pos.X)},{formatFloat(turnin.Pos.Y)},{formatFloat(turnin.Pos.Z)}";
             var col = (continueOnLevel) ? " and Core.Player.ClassLevel &lt; " + (leve.Level >=50 ? leve.Level + 2 : leve.Level + 5) : "";
             return $@"
-        <While condition=""ItemCount({leve.ItemId}) &gt; {leve.NumItems - 1}{col} and  Core.Player.ClassLevel &gt;= {leve.Level}"">
+        <While condition=""ItemCount({leve.ItemId}) &gt; {leve.NumItems - 1}{col} and Core.Player.ClassLevel &gt;= {leve.Level}"">
             <If Condition=""not IsOnMap({pickup.MapId})"">
                 <GetTo ZoneId=""{pickup.MapId}"" XYZ=""{pickuploc}"" />
             </If>
-            <ExPickupGuildLeve leveIds=""{leve.LeveId}"" leveType=""Tradecraft"" npcId=""{pickup.NpcId}"" npcLocation=""{pickuploc}"" />
+            <ExPickupGuildLeve LeveIds=""{leve.LeveId}"" LeveType=""Tradecraft"" NpcId=""{pickup.NpcId}"" NpcLocation=""{pickuploc}"" Timeout=""5"" />
             <If Condition=""not IsOnMap({turnin.MapId})"">
                 <GetTo ZoneId=""{turnin.MapId}"" XYZ=""{turninloc}"" />
             </If>
-            <ExTurnInGuildLeve npcId=""{turnin.NpcId}"" npcLocation=""{turninloc}"" />
+            <ExTurnInGuildLeve NpcId=""{turnin.NpcId}"" NpcLocation=""{turninloc}"" />
         </While>"
                 ;
 


### PR DESCRIPTION
Restoring a change I lost from my rebase.

Since ExPickupGuildLeve takes complete control over the Levemate window and does not allow inputs during operation, it is irritating to see it work with the long, default timeout and gives the impression of the game being locked up (minus hammering ESC to force a close of the window).

The 5 second pickup time is on par with how the behavior acted before Stormblood and preferable to changing the default on ExBuddy itself.

Also changed the attribute casing to be in line with how they are defined in ExBuddy itself. This is purely cosmetic.