### PR TITLE
Small quality of life changes

### DIFF
--- a/GUI/MainView.xaml
+++ b/GUI/MainView.xaml
@@ -27,6 +27,7 @@
                     <RowDefinition Height="*" />
                     <RowDefinition Height="30" />
                     <RowDefinition Height="30" />
+                    <RowDefinition Height="30" />
                 </Grid.RowDefinitions>
                 <StackPanel Orientation="Horizontal" Grid.Row="0">
                     <Button Content="{x:Static L:Localization.AddBtn}" Command="{Binding Add}" Margin="5" />
@@ -41,8 +42,9 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ListView>
-                <CheckBox Grid.Row="2" Margin="5" Content="{x:Static L:Localization.OptimizeExp}" ToolTip="{x:Static L:Localization.OptimizeExpDesc}" IsChecked="{Binding ContinueOnLevel}" />
-                <CheckBox Grid.Row="3" Margin="5" Content="{x:Static L:Localization.MakeLizbeth}" ToolTip="{x:Static L:Localization.MakeLizbethDesc}" IsChecked="{Binding GenerateLisbeth}" />
+                <CheckBox Grid.Row="2" Margin="5" Content="{x:Static L:Localization.HqOnly}" ToolTip="{x:Static L:Localization.HqOnlyDesc}" IsChecked="{Binding TurninHqOnly}" />
+                <CheckBox Grid.Row="3" Margin="5" Content="{x:Static L:Localization.OptimizeExp}" ToolTip="{x:Static L:Localization.OptimizeExpDesc}" IsChecked="{Binding ContinueOnLevel}" />
+                <CheckBox Grid.Row="4" Margin="5" Content="{x:Static L:Localization.MakeLizbeth}" ToolTip="{x:Static L:Localization.MakeLizbethDesc}" IsChecked="{Binding GenerateLisbeth}" />
             </Grid>
             <Grid Grid.Column="0">
                 <Grid.RowDefinitions>

--- a/Localization/Localization.Designer.cs
+++ b/Localization/Localization.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace LeveGen.Localization {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace LeveGen.Localization {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Localization {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Localization() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace LeveGen.Localization {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace LeveGen.Localization {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
@@ -68,7 +68,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("AddBtn", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Alchemist.
         /// </summary>
@@ -77,7 +77,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("ALC", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Armorer.
         /// </summary>
@@ -86,7 +86,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("ARM", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Blacksmith.
         /// </summary>
@@ -95,7 +95,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("BSM", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Class.
         /// </summary>
@@ -104,7 +104,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("Class", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Clear.
         /// </summary>
@@ -113,7 +113,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("ClearBtn", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Carpenter.
         /// </summary>
@@ -122,7 +122,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("CRP", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Culinarian.
         /// </summary>
@@ -131,7 +131,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("CUL", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Exp Reward.
         /// </summary>
@@ -140,7 +140,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("ExpReward", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Goldsmith.
         /// </summary>
@@ -149,7 +149,25 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("GSM", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to HqOnly.
+        /// </summary>
+        public static string HqOnly {
+            get {
+                return ResourceManager.GetString("HqOnly", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to HqOnlyDesc.
+        /// </summary>
+        public static string HqOnlyDesc {
+            get {
+                return ResourceManager.GetString("HqOnlyDesc", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Items.
         /// </summary>
@@ -158,7 +176,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("Items", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Level.
         /// </summary>
@@ -167,7 +185,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("Level", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to LeveName.
         /// </summary>
@@ -176,7 +194,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("LeveName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Leatherworker.
         /// </summary>
@@ -185,7 +203,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("LTW", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Generate Lisbeth Orders.
         /// </summary>
@@ -194,7 +212,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("MakeLizbeth", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Create Lisbeth orders for the selected leves. If Optimize EXP is checked, it will create orders based on how many HQ items are required to get to the next tier of Leves, otherwise it will create orders to complete 5 leves..
         /// </summary>
@@ -203,7 +221,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("MakeLizbethDesc", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to # of Repeats.
         /// </summary>
@@ -212,7 +230,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("NumRepeat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Optimize Exp.
         /// </summary>
@@ -221,7 +239,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("OptimizeExp", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Only do the leve for it&apos;s level range. This is to maximize EXP.
         /// </summary>
@@ -230,7 +248,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("OptimizeExpDesc", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to # of Items.
         /// </summary>
@@ -239,7 +257,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("qtyItem", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Remove.
         /// </summary>
@@ -248,7 +266,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("RemoveBtn", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
@@ -257,7 +275,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("SaveBtn", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Saves the profile if you want to use it later.
         /// </summary>
@@ -266,7 +284,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("SaveTooltip", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Search:.
         /// </summary>
@@ -275,7 +293,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("Search", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Start.
         /// </summary>
@@ -284,7 +302,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("StartBtn", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Tradecraft.
         /// </summary>
@@ -293,7 +311,7 @@ namespace LeveGen.Localization {
                 return ResourceManager.GetString("Tradecraft", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Weaver.
         /// </summary>

--- a/Localization/Localization.resx
+++ b/Localization/Localization.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -146,6 +146,12 @@
   </data>
   <data name="GSM" xml:space="preserve">
     <value>Goldsmith</value>
+  </data>
+  <data name="HqOnly" xml:space="preserve">
+    <value>Turn-in HQ Items Only</value>
+  </data>
+  <data name="HqOnlyDesc" xml:space="preserve">
+    <value>Ensures that only HQ items will be used as turn-ins when enabled. When disabled, both NQ and HQ items will be used as turn-ins.</value>
   </data>
   <data name="Items" xml:space="preserve">
     <value>Items</value>

--- a/Localization/Localization.zh-CN.resx
+++ b/Localization/Localization.zh-CN.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -146,6 +146,12 @@
   </data>
   <data name="GSM" xml:space="preserve">
     <value>雕金匠</value>
+  </data>
+  <data name="HqOnly" xml:space="preserve">
+    <value>只提供高品质的项目</value>
+  </data>
+  <data name="HqOnlyDesc" xml:space="preserve">
+    <value>当启用时，只有高品质的项目将被移交。 残疾时，正常的质量和高品质的物品将被交付。</value>
   </data>
   <data name="Items" xml:space="preserve">
     <value>物品</value>

--- a/Models/WindowModelProvider.cs
+++ b/Models/WindowModelProvider.cs
@@ -19,8 +19,6 @@ using ff14bot.NeoProfiles;
 
 namespace LeveGen.Models
 {
-
-    
     public class WindowModelProvider : INotifyPropertyChanged
     {
         private LeveDatabase _database;
@@ -81,7 +79,7 @@ namespace LeveGen.Models
 
                     using (var stream = File.OpenWrite(file))
                     {
-                        LeveGenerator.Generate(_database, CurrentOrder, ContinueOnLevel, GenerateLisbeth, stream);
+                        LeveGenerator.Generate(_database, CurrentOrder, ContinueOnLevel, TurninHqOnly, GenerateLisbeth, stream);
                     }
 
                     try
@@ -116,7 +114,7 @@ namespace LeveGen.Models
                     {
                         using (var savestrem = sr.OpenFile())
                         {
-                            LeveGenerator.Generate(_database, CurrentOrder, ContinueOnLevel, GenerateLisbeth, savestrem);
+                            LeveGenerator.Generate(_database, CurrentOrder, ContinueOnLevel, TurninHqOnly, GenerateLisbeth, savestrem);
                         }
                     }
 
@@ -187,7 +185,7 @@ namespace LeveGen.Models
 
         private bool FilterMatches(string term)
         {
-            return (term.IndexOf(Search, StringComparison.OrdinalIgnoreCase) >= 0);
+            return term.IndexOf(Search, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private bool Filter(Leve i)
@@ -240,6 +238,18 @@ namespace LeveGen.Models
             set
             {
                 _search = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private bool _TurnInHqOnly;
+
+        public bool TurninHqOnly
+        {
+            get { return _TurnInHqOnly; }
+            set
+            {
+                _TurnInHqOnly = value;
                 OnPropertyChanged();
             }
         }


### PR DESCRIPTION
## Check leve allowances count as part of the While condition.
Ensures the OrderBot profile will check whether the player has any leve allowances remaining before accepting the levequest.

## New option to turn-in HQ items only.
Because why not.
Note: This does not change the Lisbeth crafting in any way. While the main While loop will check with NqItemCount instead of ItemCount, the crafting loop will still check with ItemCount.

This is to prevent an unwanted scenario where a player would not be able to produce HQ variants of an item and thus get stuck in a crafting loop.